### PR TITLE
Add Minecraft UUID linking to profile modal

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -696,6 +696,36 @@
             <p>
               Verbinde deinen Minecraft-Account, um Profildaten zu speichern und deinen Namen in der Item-Liste erscheinen zu lassen.
             </p>
+            <form class="space-y-2" data-profile-mc-form>
+              <div class="space-y-1">
+                <label
+                  for="profile-mc-uuid"
+                  class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
+                >
+                  Minecraft UUID
+                </label>
+                <input
+                  id="profile-mc-uuid"
+                  name="mc_uuid"
+                  type="text"
+                  inputmode="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  maxlength="36"
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                  class="w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 disabled:cursor-not-allowed disabled:opacity-60"
+                  data-profile-mc-uuid-input
+                />
+              </div>
+              <p class="hidden text-xs text-rose-400" aria-live="polite" data-profile-mc-error></p>
+              <button
+                type="submit"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus:outline-none focus-visible:ring focus-visible:ring-emerald-500/60 disabled:cursor-not-allowed disabled:opacity-60"
+                data-profile-mc-submit
+              >
+                Mit Minecraft Account verbinden
+              </button>
+            </form>
             <p class="text-xs text-slate-500">
               Hinweis: Die Anmeldung wird aktuell nicht bereitgestellt – nutze die Supabase Auth Integration in deiner produktiven Instanz.
             </p>


### PR DESCRIPTION
## Summary
- add a Minecraft UUID form to the profile modal so players can link their account data
- load and display the stored UUID and validate inputs before updating the profile
- persist the UUID in Supabase profiles.mc_uuid with appropriate loading and error handling

## Testing
- node node_modules/vite/bin/vite.js build

------
https://chatgpt.com/codex/tasks/task_e_68d3d99c60588324a323148b8c450a00