### PR TITLE
Scope API routes under shared base path

### DIFF
--- a/worker/src/bindings.ts
+++ b/worker/src/bindings.ts
@@ -1,0 +1,6 @@
+export type Bindings = {
+  SUPABASE_URL: string
+  SUPABASE_ANON_KEY: string
+  SUPABASE_SERVICE_ROLE_KEY: string
+  // CACHE?: KVNamespace // optional, wenn du KV Cache nutzt
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,14 +1,9 @@
 import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { createClient } from '@supabase/supabase-js'
-import meta from './routes/meta'
+import type { Bindings } from './bindings'
+import { fetchItemTypesList, fetchMaterialsList, fetchRaritiesList } from './routes/meta'
 import { ItemInsertSchema, type ItemInsert, coerceInts } from './schemas'
-
-type Bindings = {
-  SUPABASE_URL: string
-  SUPABASE_ANON_KEY: string
-  SUPABASE_SERVICE_ROLE_KEY: string
-  // CACHE?: KVNamespace // optional, wenn du KV Cache nutzt
-}
 
 type SupabaseClient = ReturnType<typeof createClient<any, any>>
 
@@ -652,6 +647,7 @@ async function insertItemWithEnchantments(
 }
 
 const app = new Hono<{ Bindings: Bindings }>()
+const api = app.basePath('/api')
 
 const sanitizeSearchValue = (value: string) =>
   value
@@ -693,11 +689,32 @@ const cors = (overrides: Record<string, string> = {}) => ({
   ...overrides,
 })
 
+const handleMetaError = (
+  c: Context<{ Bindings: Bindings }>,
+  scope: string,
+  error: unknown,
+  fallbackMessage: string
+) => {
+  console.error(`[worker:meta:${scope}]`, error)
+  const status =
+    typeof (error as { status?: number } | null)?.status === 'number'
+      ? (error as { status?: number }).status
+      : 500
+  const message =
+    error instanceof Error && error.message ? error.message : fallbackMessage
+
+  return c.json({ error: message }, status as any, cors())
+}
+
+const META_CACHE_HEADERS = {
+  'cache-control': 'public, max-age=300, stale-while-revalidate=300',
+}
+
 // Healthcheck
-app.get('/api/health', (c) => c.text('ok'))
+api.get('/health', (c) => c.text('ok'))
 
 // Quick diagnostics for environment configuration
-app.get('/api/diag', (c) => {
+api.get('/diag', (c) => {
   const env = c.env
   return c.json(
     {
@@ -711,7 +728,7 @@ app.get('/api/diag', (c) => {
 })
 
 // Debug echo endpoint
-app.all('/api/debug/echo', async (c) => {
+api.all('/debug/echo', async (c) => {
   let rawBody = ''
   try {
     rawBody = await c.req.text()
@@ -780,10 +797,35 @@ app.options('*', (c) =>
   c.body(null, 204, cors({ 'content-type': 'text/plain; charset=UTF-8', 'Access-Control-Max-Age': '600' }))
 )
 
-app.route('/api', meta)
+api.get('/materials', async (c) => {
+  try {
+    const data = await fetchMaterialsList(c.env)
+    return c.json(data, 200, cors(META_CACHE_HEADERS))
+  } catch (error) {
+    return handleMetaError(c, 'materials', error, 'Materialien konnten nicht geladen werden.')
+  }
+})
+
+api.get('/item_types', async (c) => {
+  try {
+    const data = await fetchItemTypesList(c.env)
+    return c.json(data, 200, cors(META_CACHE_HEADERS))
+  } catch (error) {
+    return handleMetaError(c, 'item_types', error, 'Item-Typen konnten nicht geladen werden.')
+  }
+})
+
+api.get('/rarities', async (c) => {
+  try {
+    const data = await fetchRaritiesList(c.env)
+    return c.json(data, 200, cors(META_CACHE_HEADERS))
+  } catch (error) {
+    return handleMetaError(c, 'rarities', error, 'Seltenheiten konnten nicht geladen werden.')
+  }
+})
 
 // GET /api/items
-app.get('/api/items', async (c) => {
+api.get('/items', async (c) => {
   const query = c.req.query()
   const params = new URLSearchParams({
     select:
@@ -848,7 +890,7 @@ app.get('/api/items', async (c) => {
 })
 
 // POST /api/items (validiert + Service-Role)
-app.post('/api/items', async (c) => {
+api.post('/items', async (c) => {
   const token = resolveSupabaseBearerToken(c.req)
 
   if (!token) {
@@ -1006,7 +1048,7 @@ app.post('/api/items', async (c) => {
 })
 
 // GET /api/enchantments (lange cachen)
-app.get('/api/enchantments', async (c) => {
+api.get('/enchantments', async (c) => {
   const res = await fetch(`${c.env.SUPABASE_URL}/rest/v1/enchantments?select=*`, {
     headers: { apikey: c.env.SUPABASE_ANON_KEY }
   })


### PR DESCRIPTION
## Summary
- create a shared `/api` base path for the worker and register every endpoint beneath it so `/api/items` is no longer shadowed by other route registrations
- leave the existing handlers untouched while ensuring health, diag, metadata, item, and enchantment requests all resolve through the same router

## Testing
- npm --prefix worker run types

------
https://chatgpt.com/codex/tasks/task_e_68d3cb9752d08324af550479a8a0a8f3