### PR TITLE
Ensure Minecraft avatar render loads eagerly

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -696,6 +696,57 @@
             <p>
               Verbinde deinen Minecraft-Account, um Profildaten zu speichern und deinen Namen in der Item-Liste erscheinen zu lassen.
             </p>
+            <form class="space-y-2" data-profile-mc-form>
+              <div class="space-y-1">
+                <label
+                  for="profile-mc-uuid"
+                  class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500"
+                >
+                  Minecraft UUID
+                </label>
+                <input
+                  id="profile-mc-uuid"
+                  name="mc_uuid"
+                  type="text"
+                  inputmode="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  maxlength="36"
+                  placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                  class="w-full rounded-lg border border-slate-800 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500/40 disabled:cursor-not-allowed disabled:opacity-60"
+                  data-profile-mc-uuid-input
+                />
+              </div>
+              <p class="hidden text-xs text-rose-400" aria-live="polite" data-profile-mc-error></p>
+              <button
+                type="submit"
+                class="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400 focus:outline-none focus-visible:ring focus-visible:ring-emerald-500/60 disabled:cursor-not-allowed disabled:opacity-60"
+                data-profile-mc-submit
+              >
+                Mit Minecraft Account verbinden
+              </button>
+            </form>
+            <div
+              class="hidden items-center gap-4 rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-4 text-slate-100 shadow-inner shadow-emerald-500/10"
+              data-profile-mc-connected
+            >
+              <div
+                class="relative flex h-14 w-14 items-center justify-center overflow-hidden rounded-lg border border-emerald-500/40 bg-slate-950 text-lg font-semibold uppercase tracking-wide text-emerald-300"
+              >
+                <img
+                  data-profile-mc-avatar-image
+                  class="hidden h-full w-full object-cover"
+                  alt=""
+                />
+                <span data-profile-mc-avatar-fallback>MC</span>
+              </div>
+              <div class="space-y-1 text-left">
+                <p class="text-xs uppercase tracking-[0.2em] text-emerald-300/80">
+                  Minecraft Account
+                </p>
+                <p class="text-sm font-semibold text-slate-100" data-profile-mc-name>–</p>
+              </div>
+            </div>
             <p class="text-xs text-slate-500">
               Hinweis: Die Anmeldung wird aktuell nicht bereitgestellt – nutze die Supabase Auth Integration in deiner produktiven Instanz.
             </p>

--- a/app/public/public/js/app.js
+++ b/app/public/public/js/app.js
@@ -135,6 +135,9 @@ const MINECRAFT_PROFILE_API_BASE_URL = 'https://mc-api.io/profile'
 const MINECRAFT_RENDER_API_BASE_URL = 'https://mc-api.io/render'
 const MINECRAFT_RENDER_FACE_DEFAULT_SIZE = 128
 
+const minecraftRenderFaceCache = new Map()
+const minecraftRenderFacePromises = new Map()
+
 
 const insertDiagnostics = {
   lastMethod: null,
@@ -1637,6 +1640,68 @@ function getMinecraftRenderFaceUrl(normalisedUuid, size = MINECRAFT_RENDER_FACE_
   }
 }
 
+function getMinecraftRenderCacheKey(normalisedUuid, size) {
+  return `${normalisedUuid}:${size}`
+}
+
+function loadMinecraftRenderFace(normalisedUuid, size = MINECRAFT_RENDER_FACE_DEFAULT_SIZE) {
+  const cacheKey = getMinecraftRenderCacheKey(normalisedUuid, size)
+  const cached = minecraftRenderFaceCache.get(cacheKey)
+  if (cached && cached.url) {
+    return Promise.resolve(cached)
+  }
+
+  const pending = minecraftRenderFacePromises.get(cacheKey)
+  if (pending) {
+    return pending
+  }
+
+  const renderUrl = getMinecraftRenderFaceUrl(normalisedUuid, size)
+  if (!renderUrl) {
+    return Promise.reject(new Error('Ungültige Minecraft UUID für das Render-Bild.'))
+  }
+
+  const canUseImageConstructor = typeof Image === 'function'
+
+  if (!canUseImageConstructor) {
+    const fallbackPayload = { url: renderUrl, width: size, height: size }
+    minecraftRenderFaceCache.set(cacheKey, fallbackPayload)
+    return Promise.resolve(fallbackPayload)
+  }
+
+  const promise = new Promise((resolve, reject) => {
+    const loader = new Image()
+    loader.decoding = 'async'
+    loader.loading = 'eager'
+    loader.crossOrigin = 'anonymous'
+    loader.referrerPolicy = 'no-referrer'
+
+    loader.addEventListener('load', () => {
+      const payload = {
+        url: renderUrl,
+        width: loader.naturalWidth || size,
+        height: loader.naturalHeight || size,
+      }
+      minecraftRenderFaceCache.set(cacheKey, payload)
+      minecraftRenderFacePromises.delete(cacheKey)
+      resolve(payload)
+    })
+
+    loader.addEventListener('error', (event) => {
+      minecraftRenderFacePromises.delete(cacheKey)
+      const error = new Error('Minecraft Kopf konnte nicht geladen werden.')
+      error.code = 'MINECRAFT_RENDER_ERROR'
+      error.event = event
+      reject(error)
+    })
+
+    loader.src = renderUrl
+  })
+
+  minecraftRenderFacePromises.set(cacheKey, promise)
+  return promise
+}
+
 async function fetchMinecraftProfileByUuid(normalisedUuid) {
   const formattedUuid = formatMinecraftUuidForDisplay(normalisedUuid)
   if (!formattedUuid) {
@@ -1714,28 +1779,26 @@ async function fetchMinecraftProfileByUuid(normalisedUuid) {
 function setProfileMinecraftAvatar(normalisedUuid, displayName) {
   const image = profileModalElements.mcConnectedAvatarImage
   const fallback = profileModalElements.mcConnectedAvatarFallback
+  const trimmedName = typeof displayName === 'string' ? displayName.trim() : ''
+  const fallbackText = trimmedName ? trimmedName.charAt(0).toUpperCase() : 'MC'
+
   if (!image) {
     if (fallback) {
-      const fallbackText =
-        typeof displayName === 'string' && displayName.trim()
-          ? displayName.trim().charAt(0).toUpperCase()
-          : 'MC'
       fallback.textContent = fallbackText
       fallback.classList.remove('hidden')
     }
     return
   }
 
-  const trimmedName = typeof displayName === 'string' ? displayName.trim() : ''
-  const fallbackText = trimmedName ? trimmedName.charAt(0).toUpperCase() : 'MC'
-  const hasUuid = Boolean(normalisedUuid)
-
   if (fallback) {
     fallback.textContent = fallbackText
   }
 
+  const hasUuid = Boolean(normalisedUuid)
+
   if (!hasUuid) {
     delete image.dataset.renderUuid
+    delete image.dataset.renderSize
     image.dataset.fallbackText = fallbackText
     image.removeAttribute('src')
     image.alt = ''
@@ -1746,50 +1809,86 @@ function setProfileMinecraftAvatar(normalisedUuid, displayName) {
     return
   }
 
-  const altText = trimmedName ? `Minecraft Kopf von ${trimmedName}` : 'Minecraft Kopf'
-  const renderUrl = getMinecraftRenderFaceUrl(normalisedUuid)
+  const renderSize = MINECRAFT_RENDER_FACE_DEFAULT_SIZE
+  const renderUrl = getMinecraftRenderFaceUrl(normalisedUuid, renderSize)
   const previousUuid = typeof image.dataset.renderUuid === 'string' ? image.dataset.renderUuid : ''
   const previousSrc = image.getAttribute('src') || ''
+  const altText = trimmedName ? `Minecraft Kopf von ${trimmedName}` : 'Minecraft Kopf'
   const isSameImage = previousUuid === normalisedUuid && previousSrc === renderUrl
 
   image.dataset.fallbackText = fallbackText
+  image.dataset.renderUuid = normalisedUuid
+  image.dataset.renderSize = String(renderSize)
+  image.alt = altText
 
-  if (isSameImage && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0) {
-    image.alt = altText
+  const revealAvatar = (url) => {
+    if (!url || image.dataset.renderUuid !== normalisedUuid) {
+      return
+    }
+
+    if (image.getAttribute('src') !== url) {
+      image.src = url
+    }
+
+    if (typeof image.loading === 'string') {
+      image.loading = 'eager'
+    } else if (image.getAttribute('loading') === 'lazy') {
+      image.setAttribute('loading', 'eager')
+    }
+
     image.classList.remove('hidden')
     if (fallback) {
       fallback.classList.add('hidden')
     }
+  }
+
+  const handleRenderFailure = (error) => {
+    if (image.dataset.renderUuid !== normalisedUuid) {
+      return
+    }
+
+    image.classList.add('hidden')
+    image.removeAttribute('src')
+    image.alt = ''
+    delete image.dataset.renderUuid
+    delete image.dataset.renderSize
+
+    if (fallback) {
+      fallback.textContent = fallbackText
+      fallback.classList.remove('hidden')
+    }
+
+    if (error) {
+      console.warn('[profile] Minecraft Kopf konnte nicht geladen werden.', error)
+    }
+  }
+
+  if (isSameImage && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0) {
+    revealAvatar(previousSrc)
     return
   }
 
-  image.dataset.renderUuid = normalisedUuid
-  image.alt = altText
+  const cacheKey = getMinecraftRenderCacheKey(normalisedUuid, renderSize)
+  const cached = minecraftRenderFaceCache.get(cacheKey)
+
+  if (cached && cached.url) {
+    revealAvatar(cached.url)
+    return
+  }
+
   image.classList.add('hidden')
   if (fallback) {
     fallback.classList.remove('hidden')
   }
-  if (typeof image.loading === 'string') {
-    image.loading = 'eager'
-  } else if (image.getAttribute('loading') === 'lazy') {
-    image.setAttribute('loading', 'eager')
-  }
-  image.src = renderUrl
 
-  if (image.complete) {
-    setTimeout(() => {
-      if (image.dataset.renderUuid !== normalisedUuid) {
-        return
-      }
-
-      if (image.naturalWidth > 0 && image.naturalHeight > 0) {
-        image.classList.remove('hidden')
-        if (fallback) {
-          fallback.classList.add('hidden')
-        }
-      }
-    }, 0)
-  }
+  loadMinecraftRenderFace(normalisedUuid, renderSize)
+    .then((result) => {
+      const resolvedUrl = result && result.url ? result.url : renderUrl
+      revealAvatar(resolvedUrl)
+    })
+    .catch((error) => {
+      handleRenderFailure(error)
+    })
 }
 
 function setProfileMcUuidError(message) {

--- a/app/public/public/js/app.js
+++ b/app/public/public/js/app.js
@@ -66,6 +66,14 @@ const profileModalElements = (() => {
     likes: modal?.querySelector('[data-profile-likes]') ?? null,
     loading: modal?.querySelector('[data-profile-loading]') ?? null,
     error: modal?.querySelector('[data-profile-error]') ?? null,
+    mcUuidForm: modal?.querySelector('[data-profile-mc-form]') ?? null,
+    mcUuidInput: modal?.querySelector('[data-profile-mc-uuid-input]') ?? null,
+    mcUuidButton: modal?.querySelector('[data-profile-mc-submit]') ?? null,
+    mcUuidError: modal?.querySelector('[data-profile-mc-error]') ?? null,
+    mcConnected: modal?.querySelector('[data-profile-mc-connected]') ?? null,
+    mcConnectedName: modal?.querySelector('[data-profile-mc-name]') ?? null,
+    mcConnectedAvatarImage: modal?.querySelector('[data-profile-mc-avatar-image]') ?? null,
+    mcConnectedAvatarFallback: modal?.querySelector('[data-profile-mc-avatar-fallback]') ?? null,
   }
 })()
 
@@ -73,6 +81,8 @@ const profileModalState = {
   isOpen: false,
   lastFocusedElement: null,
   activeFetchToken: 0,
+  mcUuidSubmitting: false,
+  mcUuidInputDirty: false,
 }
 
 const MODERATION_ROLES = new Set(['moderator', 'admin'])
@@ -121,6 +131,10 @@ const IMAGE_MIME_EXTENSION_MAP = {
 };
 
 const API_BASE = '/api'
+const MINECRAFT_PROFILE_API_BASE_URL = 'https://mc-api.io/profile'
+const MINECRAFT_RENDER_API_BASE_URL = 'https://mc-api.io/render'
+const MINECRAFT_RENDER_FACE_DEFAULT_SIZE = 128
+
 
 const insertDiagnostics = {
   lastMethod: null,
@@ -1487,6 +1501,12 @@ function getProfileDisplayName() {
     return profileName
   }
 
+  const profileMcName =
+    typeof state.profile?.mc_name === 'string' ? state.profile.mc_name.trim() : ''
+  if (profileMcName) {
+    return profileMcName
+  }
+
   const metadata =
     state.user.user_metadata && typeof state.user.user_metadata === 'object'
       ? state.user.user_metadata
@@ -1569,6 +1589,283 @@ function setProfileModalError(message) {
   }
 }
 
+function normaliseMinecraftUuid(value) {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  const trimmed = value.trim().toLowerCase()
+  if (!trimmed) {
+    return ''
+  }
+
+  const sanitized = trimmed.replace(/-/g, '')
+  if (!/^[0-9a-f]{32}$/.test(sanitized)) {
+    return ''
+  }
+
+  return sanitized
+}
+
+function formatMinecraftUuidForDisplay(value) {
+  const normalised = normaliseMinecraftUuid(value)
+  if (!normalised) {
+    return ''
+  }
+
+  return normalised.replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, '$1-$2-$3-$4-$5')
+}
+
+function getMinecraftRenderFaceUrl(normalisedUuid, size = MINECRAFT_RENDER_FACE_DEFAULT_SIZE) {
+  const formattedUuid = formatMinecraftUuidForDisplay(normalisedUuid)
+  if (!formattedUuid) {
+    return ''
+  }
+
+  const numericSize = Number(size)
+  const defaultSize = MINECRAFT_RENDER_FACE_DEFAULT_SIZE
+  const resolvedSize = Number.isFinite(numericSize)
+    ? Math.min(512, Math.max(32, Math.round(Math.max(numericSize, 0))))
+    : defaultSize
+
+  try {
+    const url = new URL(`${MINECRAFT_RENDER_API_BASE_URL}/face/${formattedUuid}`)
+    url.searchParams.set('size', String(resolvedSize))
+    return url.toString()
+  } catch (error) {
+    return `${MINECRAFT_RENDER_API_BASE_URL}/face/${formattedUuid}?size=${resolvedSize}`
+  }
+}
+
+async function fetchMinecraftProfileByUuid(normalisedUuid) {
+  const formattedUuid = formatMinecraftUuidForDisplay(normalisedUuid)
+  if (!formattedUuid) {
+    const error = new Error('Ungültige Minecraft UUID.')
+    error.code = 'MINECRAFT_PROFILE_INVALID_UUID'
+    throw error
+  }
+
+  const requestUrl = `${MINECRAFT_PROFILE_API_BASE_URL}/${formattedUuid}`
+  let response
+
+  try {
+    response = await fetch(requestUrl, {
+      headers: { Accept: 'application/json' },
+      method: 'GET',
+    })
+  } catch (networkError) {
+    const error = new Error(
+      'Die Minecraft API konnte nicht erreicht werden. Bitte versuche es später erneut.'
+    )
+    error.code = 'MINECRAFT_PROFILE_NETWORK'
+    error.cause = networkError
+    throw error
+  }
+
+  let payload = null
+  try {
+    payload = await response.json()
+  } catch (parseError) {
+    payload = null
+  }
+
+  if (!response.ok) {
+    const isNotFound = response.status === 404
+    const message = isNotFound
+      ? 'Es wurde kein Minecraft Account mit dieser UUID gefunden.'
+      : 'Die Minecraft API hat einen Fehler zurückgegeben. Bitte versuche es später erneut.'
+    const error = new Error(message)
+    error.code = isNotFound ? 'MINECRAFT_PROFILE_NOT_FOUND' : 'MINECRAFT_PROFILE_API'
+    error.status = response.status
+    if (payload && typeof payload.message === 'string') {
+      error.details = payload.message
+    }
+    throw error
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    const error = new Error('Die Minecraft API hat eine ungültige Antwort geliefert.')
+    error.code = 'MINECRAFT_PROFILE_INVALID_RESPONSE'
+    throw error
+  }
+
+  if (payload.error) {
+    const message =
+      typeof payload.message === 'string' && payload.message.trim()
+        ? payload.message.trim()
+        : 'Die Minecraft API hat einen Fehler gemeldet.'
+    const error = new Error(message)
+    error.code = 'MINECRAFT_PROFILE_API'
+    throw error
+  }
+
+  const playerName = typeof payload.name === 'string' ? payload.name.trim() : ''
+  if (!playerName) {
+    const error = new Error('Die Minecraft API hat keinen Spielernamen zurückgegeben.')
+    error.code = 'MINECRAFT_PROFILE_INVALID_RESPONSE'
+    throw error
+  }
+
+  const uuidFromApi = normaliseMinecraftUuid(payload.uuid ?? formattedUuid) || normalisedUuid
+
+  return { name: playerName, uuid: uuidFromApi }
+}
+
+function setProfileMinecraftAvatar(normalisedUuid, displayName) {
+  const image = profileModalElements.mcConnectedAvatarImage
+  const fallback = profileModalElements.mcConnectedAvatarFallback
+  if (!image) {
+    if (fallback) {
+      const fallbackText =
+        typeof displayName === 'string' && displayName.trim()
+          ? displayName.trim().charAt(0).toUpperCase()
+          : 'MC'
+      fallback.textContent = fallbackText
+      fallback.classList.remove('hidden')
+    }
+    return
+  }
+
+  const trimmedName = typeof displayName === 'string' ? displayName.trim() : ''
+  const fallbackText = trimmedName ? trimmedName.charAt(0).toUpperCase() : 'MC'
+  const hasUuid = Boolean(normalisedUuid)
+
+  if (fallback) {
+    fallback.textContent = fallbackText
+  }
+
+  if (!hasUuid) {
+    delete image.dataset.renderUuid
+    image.dataset.fallbackText = fallbackText
+    image.removeAttribute('src')
+    image.alt = ''
+    image.classList.add('hidden')
+    if (fallback) {
+      fallback.classList.remove('hidden')
+    }
+    return
+  }
+
+  const altText = trimmedName ? `Minecraft Kopf von ${trimmedName}` : 'Minecraft Kopf'
+  const renderUrl = getMinecraftRenderFaceUrl(normalisedUuid)
+  const previousUuid = typeof image.dataset.renderUuid === 'string' ? image.dataset.renderUuid : ''
+  const previousSrc = image.getAttribute('src') || ''
+  const isSameImage = previousUuid === normalisedUuid && previousSrc === renderUrl
+
+  image.dataset.fallbackText = fallbackText
+
+  if (isSameImage && image.complete && image.naturalWidth > 0 && image.naturalHeight > 0) {
+    image.alt = altText
+    image.classList.remove('hidden')
+    if (fallback) {
+      fallback.classList.add('hidden')
+    }
+    return
+  }
+
+  image.dataset.renderUuid = normalisedUuid
+  image.alt = altText
+  image.classList.add('hidden')
+  if (fallback) {
+    fallback.classList.remove('hidden')
+  }
+  if (typeof image.loading === 'string') {
+    image.loading = 'eager'
+  } else if (image.getAttribute('loading') === 'lazy') {
+    image.setAttribute('loading', 'eager')
+  }
+  image.src = renderUrl
+
+  if (image.complete) {
+    setTimeout(() => {
+      if (image.dataset.renderUuid !== normalisedUuid) {
+        return
+      }
+
+      if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+        image.classList.remove('hidden')
+        if (fallback) {
+          fallback.classList.add('hidden')
+        }
+      }
+    }, 0)
+  }
+}
+
+function setProfileMcUuidError(message) {
+  const element = profileModalElements.mcUuidError
+  if (!element) return
+
+  if (message) {
+    element.textContent = message
+    element.classList.remove('hidden')
+  } else {
+    element.textContent = ''
+    element.classList.add('hidden')
+  }
+}
+
+function updateProfileMcUuidFormState() {
+  const hasUser = Boolean(state.user)
+  const isSubmitting = profileModalState.mcUuidSubmitting
+  const profileData =
+    hasUser && state.profile && typeof state.profile === 'object' ? state.profile : null
+  const rawUuid = profileData && typeof profileData.mc_uuid === 'string' ? profileData.mc_uuid : ''
+  const normalisedUuid = normaliseMinecraftUuid(rawUuid)
+  const isConnected = hasUser && Boolean(normalisedUuid)
+  const rawName = profileData && typeof profileData.mc_name === 'string' ? profileData.mc_name : ''
+  const mcName = rawName.trim()
+  const formattedUuid = formatMinecraftUuidForDisplay(normalisedUuid)
+
+  if (isConnected) {
+    profileModalState.mcUuidInputDirty = false
+  }
+
+  if (profileModalElements.mcUuidForm) {
+    profileModalElements.mcUuidForm.classList.toggle('hidden', isConnected)
+    profileModalElements.mcUuidForm.setAttribute(
+      'aria-hidden',
+      String(isConnected)
+    )
+    profileModalElements.mcUuidForm.setAttribute(
+      'aria-disabled',
+      String(!hasUser || isSubmitting || isConnected)
+    )
+  }
+
+  if (profileModalElements.mcUuidInput) {
+    profileModalElements.mcUuidInput.disabled = !hasUser || isSubmitting || isConnected
+    if (!hasUser) {
+      profileModalElements.mcUuidInput.value = ''
+      profileModalState.mcUuidInputDirty = false
+    } else if (!profileModalState.mcUuidInputDirty) {
+      profileModalElements.mcUuidInput.value = formattedUuid
+    }
+  }
+
+  if (profileModalElements.mcUuidButton) {
+    profileModalElements.mcUuidButton.disabled = !hasUser || isSubmitting || isConnected
+    const defaultLabel = 'Mit Minecraft Account verbinden'
+    const loadingLabel = 'Verbinden…'
+    profileModalElements.mcUuidButton.textContent = isSubmitting ? loadingLabel : defaultLabel
+  }
+
+  if (profileModalElements.mcConnected) {
+    profileModalElements.mcConnected.classList.toggle('hidden', !isConnected)
+  }
+
+  if (profileModalElements.mcConnectedName) {
+    const displayName = mcName || formattedUuid || '–'
+    profileModalElements.mcConnectedName.textContent = displayName
+  }
+
+  setProfileMinecraftAvatar(isConnected ? normalisedUuid : '', mcName)
+
+  if (!hasUser || isConnected) {
+    setProfileMcUuidError('')
+  }
+}
+
 function updateProfileModalUserInfo() {
   if (!profileModalElements.modal) {
     return
@@ -1595,6 +1892,8 @@ function updateProfileModalUserInfo() {
   if (profileModalElements.avatarFrame) {
     profileModalElements.avatarFrame.classList.toggle('bg-slate-900/80', !url)
   }
+
+  updateProfileMcUuidFormState()
 
   if (!hasUser) {
     setProfileModalCounts('–', '–')
@@ -1742,6 +2041,9 @@ function openProfileModal() {
     return
   }
 
+  profileModalState.mcUuidInputDirty = false
+  setProfileMcUuidError('')
+
   profileModalState.lastFocusedElement =
     document.activeElement instanceof HTMLElement ? document.activeElement : null
 
@@ -1795,6 +2097,173 @@ function openProfileModal() {
     }
   }
 }
+
+async function handleProfileMcUuidSubmit(event) {
+  event.preventDefault()
+
+  if (profileModalState.mcUuidSubmitting) {
+    return
+  }
+
+  if (!state.user?.id) {
+    showToast('Bitte melde dich an, um deinen Minecraft Account zu verbinden.', 'info')
+    return
+  }
+
+  const input = profileModalElements.mcUuidInput
+  if (!(input instanceof HTMLInputElement)) {
+    return
+  }
+
+  const rawValue = input.value ?? ''
+  const trimmedValue = rawValue.trim()
+
+  if (!trimmedValue) {
+    setProfileMcUuidError('Bitte gib deine Minecraft UUID ein.')
+    input.focus()
+    return
+  }
+
+  const normalised = normaliseMinecraftUuid(trimmedValue)
+  if (!normalised) {
+    setProfileMcUuidError('Ungültige Minecraft UUID. Bitte überprüfe deine Eingabe.')
+    input.focus()
+    return
+  }
+
+  if (!supabase) {
+    showToast('Supabase ist nicht konfiguriert.', 'error')
+    return
+  }
+
+  profileModalState.mcUuidSubmitting = true
+  updateProfileMcUuidFormState()
+  setProfileMcUuidError('')
+
+  let confirmedUuid = normalised
+  let fetchedName = ''
+
+  try {
+    const profile = await fetchMinecraftProfileByUuid(normalised)
+    confirmedUuid = profile.uuid
+    fetchedName = profile.name
+
+    const existingProfile =
+      state.profile && typeof state.profile === 'object' ? state.profile : {}
+    const currentUuid =
+      typeof existingProfile.mc_uuid === 'string' ? existingProfile.mc_uuid : null
+    const currentName =
+      typeof existingProfile.mc_name === 'string' ? existingProfile.mc_name.trim() : ''
+
+    if (currentUuid === confirmedUuid && currentName === fetchedName) {
+      profileModalState.mcUuidInputDirty = false
+      setProfileMcUuidError('')
+      updateProfileModalUserInfo()
+      showToast('Dein Minecraft Account ist bereits verbunden.', 'info')
+      return
+    }
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ mc_uuid: confirmedUuid, mc_name: fetchedName })
+      .eq('id', state.user.id)
+
+    if (error) {
+      throw error
+    }
+
+    state.profile = {
+      ...existingProfile,
+      mc_uuid: confirmedUuid,
+      mc_name: fetchedName,
+    }
+
+    profileModalState.mcUuidInputDirty = false
+    setProfileMcUuidError('')
+    updateProfileModalUserInfo()
+    showToast(`Minecraft Account ${fetchedName} wurde verbunden.`, 'success')
+  } catch (caughtError) {
+    if (typeof caughtError?.code === 'string' && caughtError.code.startsWith('MINECRAFT_PROFILE')) {
+      console.error('[profile] Fehler beim Abrufen des Minecraft Accounts.', caughtError)
+      const message =
+        caughtError.message ||
+        'Verknüpfung mit Minecraft fehlgeschlagen. Bitte versuche es erneut.'
+      setProfileMcUuidError(message)
+      showToast(message, 'error')
+      try {
+        input.focus({ preventScroll: true })
+      } catch (focusError) {
+        input.focus()
+      }
+    } else {
+      console.error('[profile] Fehler beim Speichern der Minecraft UUID.', caughtError)
+      const code = typeof caughtError?.code === 'string' ? caughtError.code : ''
+      const messageText = typeof caughtError?.message === 'string' ? caughtError.message.toLowerCase() : ''
+      let message = 'Verknüpfung mit Minecraft fehlgeschlagen. Bitte versuche es erneut.'
+
+      if (code === '23505' || messageText.includes('duplicate')) {
+        message = 'Diese Minecraft UUID wird bereits von einem anderen Profil verwendet.'
+      }
+
+      setProfileMcUuidError(message)
+      showToast(message, 'error')
+      try {
+        input.focus({ preventScroll: true })
+      } catch (focusError) {
+        input.focus()
+      }
+    }
+  } finally {
+    profileModalState.mcUuidSubmitting = false
+    updateProfileMcUuidFormState()
+  }
+}
+
+if (profileModalElements.mcUuidInput) {
+  profileModalElements.mcUuidInput.addEventListener('input', () => {
+    profileModalState.mcUuidInputDirty = true
+    setProfileMcUuidError('')
+  })
+}
+
+if (profileModalElements.mcUuidForm) {
+  profileModalElements.mcUuidForm.addEventListener('submit', handleProfileMcUuidSubmit)
+}
+
+if (profileModalElements.mcConnectedAvatarImage) {
+  profileModalElements.mcConnectedAvatarImage.addEventListener('load', () => {
+    const image = profileModalElements.mcConnectedAvatarImage
+    if (!image || !image.dataset.renderUuid) {
+      return
+    }
+
+    image.classList.remove('hidden')
+
+    if (profileModalElements.mcConnectedAvatarFallback) {
+      profileModalElements.mcConnectedAvatarFallback.classList.add('hidden')
+    }
+  })
+
+  profileModalElements.mcConnectedAvatarImage.addEventListener('error', () => {
+    const image = profileModalElements.mcConnectedAvatarImage
+    if (!image) {
+      return
+    }
+
+    const fallbackText = image.dataset.fallbackText || 'MC'
+    image.classList.add('hidden')
+    image.removeAttribute('src')
+    image.alt = ''
+    delete image.dataset.renderUuid
+
+    if (profileModalElements.mcConnectedAvatarFallback) {
+      profileModalElements.mcConnectedAvatarFallback.textContent = fallbackText
+      profileModalElements.mcConnectedAvatarFallback.classList.remove('hidden')
+    }
+  })
+}
+
+updateProfileMcUuidFormState()
 
 if (profileModalElements.overlay) {
   profileModalElements.overlay.addEventListener('click', (event) => {
@@ -2258,7 +2727,7 @@ async function loadProfile() {
   try {
     const { data, error } = await supabase
       .from('profiles')
-      .select('username,avatar_url,bio,roles:role_id(slug,label)')
+      .select('username,avatar_url,bio,mc_uuid,mc_name,roles:role_id(slug,label)')
       .eq('id', state.user.id)
       .maybeSingle()
 
@@ -2273,17 +2742,23 @@ async function loadProfile() {
         typeof data.avatar_url === 'string' ? data.avatar_url.trim() : ''
       const bioFromDb = typeof data.bio === 'string' ? data.bio.trim() : ''
       const roleFromRelation = resolveTextValue(data.roles, ['slug', 'label'])
+      const mcUuidFromDb = typeof data.mc_uuid === 'string' ? data.mc_uuid.trim() : ''
+      const mcUuidValue = normaliseMinecraftUuid(mcUuidFromDb)
+      const mcNameFromDb = typeof data.mc_name === 'string' ? data.mc_name.trim() : ''
 
       const usernameValue = usernameFromDb || metadataFallback.username || null
       const avatarValue = avatarFromDb || metadataFallback.avatar_url || null
       const bioValue = bioFromDb || null
       const roleValue = roleFromRelation || metadataFallback.role || null
+      const mcNameValue = mcNameFromDb || null
 
       state.profile = {
         username: usernameValue,
         avatar_url: avatarValue,
         bio: bioValue,
         role: roleValue,
+        mc_uuid: mcUuidValue || null,
+        mc_name: mcNameValue,
       }
 
       const normalizedRole =
@@ -2295,6 +2770,8 @@ async function loadProfile() {
         avatar_url: metadataFallback.avatar_url ?? null,
         bio: null,
         role: metadataFallback.role ?? null,
+        mc_uuid: null,
+        mc_name: null,
       }
       state.profileRole = metadataFallbackRoleNormalized || null
     }
@@ -2305,6 +2782,8 @@ async function loadProfile() {
       avatar_url: metadataFallback.avatar_url ?? null,
       bio: null,
       role: metadataFallback.role ?? null,
+      mc_uuid: null,
+      mc_name: null,
     }
     state.profileRole = metadataFallbackRoleNormalized || null
   } finally {


### PR DESCRIPTION
## Summary
- remove the lazy-loading hint from the Minecraft avatar preview so the head render can load while the panel toggles visibility
- force the Minecraft avatar image element to request renders eagerly before swapping the src, ensuring cached heads become visible instead of falling back to initials

## Testing
- node node_modules/vite/bin/vite.js build *(fails: tracked node_modules miss the optional @rollup/rollup-linux-x64-gnu package required by rollup)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d99c60588324a323148b8c450a00