### PR TITLE
Fix worker meta route registration

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1065,10 +1065,6 @@ api.get('/enchantments', async (c) => {
   )
 })
 
-// Meta-/Referenzendpunkte zuletzt registrieren, damit sie keine
-// spezifischeren /api-Routen (z. B. /api/items) überschreiben.
-app.route('/api', meta)
-
 app.onError((err, c) => {
   console.error('[worker:onError]', err)
   return c.json({ error: (err as Error).message ?? 'Internal Error' }, 500, cors())


### PR DESCRIPTION
## Summary
- remove the leftover meta router registration in the worker entrypoint to avoid referencing an undefined symbol during deploy

## Testing
- npm run types

------
https://chatgpt.com/codex/tasks/task_e_68d42bd982148324829d892436acce05