### PR TITLE
Hoist meta shim for worker bundle

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -7,6 +7,29 @@ import { ItemInsertSchema, type ItemInsert, coerceInts } from './schemas'
 
 type SupabaseClient = ReturnType<typeof createClient<any, any>>
 
+// Cloudflare's runtime sometimes expects a global `meta` object to exist when
+// evaluating module workers. The Windows deploy reported a `ReferenceError`
+// because the identifier wasn't defined at load time, so we provide a safe
+// default here. To mirror the behaviour of Wrangler's bundler we also ensure a
+// hoisted `var meta` binding exists alongside the global property.
+declare global {
+  // eslint-disable-next-line no-var
+  var meta: unknown | undefined
+}
+
+const globalWithMeta = globalThis as typeof globalThis & { meta?: unknown }
+
+if (typeof globalWithMeta.meta === 'undefined') {
+  globalWithMeta.meta = {}
+}
+
+if (typeof meta === 'undefined') {
+  // eslint-disable-next-line no-var
+  var meta = globalWithMeta.meta
+} else if (globalWithMeta.meta !== meta) {
+  globalWithMeta.meta = meta
+}
+
 const MAX_STAR_RATING = 3
 
 type RequestLike = {


### PR DESCRIPTION
## Summary
- add a global declaration to expose a hoisted `meta` binding for the worker bundle
- synchronise the hoisted variable with `globalThis.meta` so the runtime always has a defined object

## Testing
- npx wrangler deploy --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d4328b654c8324bc069e56254b1cee