### PR TITLE
Improve add item modal accessibility

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -249,21 +249,23 @@
     >
         <div class="absolute inset-0" data-modal-overlay></div>
         <div
-          class="relative z-10 w-full max-w-2xl rounded-3xl border border-slate-800/80 bg-slate-950 p-6 text-slate-200 shadow-2xl shadow-emerald-500/10"
+          class="relative z-10 w-full max-w-2xl rounded-3xl border border-slate-800/80 bg-slate-950 p-6 text-slate-200 shadow-2xl shadow-emerald-500/10 modal-viewport"
           role="document"
         >
-          <div class="flex items-start justify-between gap-4">
+          <div class="flex items-start justify-between gap-4 sticky top-0 z-10 bg-slate-950/95 backdrop-blur supports-[backdrop-filter]:bg-slate-950/80">
             <div>
               <h2 id="addItemModalTitle" class="text-xl font-semibold text-slate-50">Neues Item hinzufügen</h2>
               <p class="mt-1 text-sm text-slate-400">
                 Fülle alle Pflichtfelder aus, um ein Item in die Datenbank zu speichern.
               </p>
+              <p class="text-xs text-slate-500 mt-2">* Pflichtfeld</p>
             </div>
             <button
               type="button"
               class="rounded-full p-2 text-slate-400 transition hover:bg-slate-900 hover:text-slate-200 focus:outline-none focus-visible:ring focus-visible:ring-emerald-500/60"
               data-modal-close
               aria-label="Modal schließen"
+              title="Schließen"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -281,7 +283,7 @@
               </svg>
             </button>
           </div>
-          <form id="addItemForm" class="mt-6 space-y-8" aria-describedby="addItemFormError" novalidate>
+          <form id="addItemForm" class="mt-6 space-y-8" aria-describedby="addItemFormError" aria-busy="false" novalidate>
             <div
               id="addItemFormError"
               class="hidden rounded-xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200"
@@ -318,7 +320,7 @@
                   >
                     <span data-character-counter-text>0 / 120 Zeichen</span>
                   </div>
-                  <p id="itemTitleError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="title"></p>
+                  <p id="itemTitleError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="title" role="alert" aria-live="assertive"></p>
                 </div>
                 <div class="grid gap-4 sm:grid-cols-3">
                   <div>
@@ -333,7 +335,7 @@
                       ></select>
                     </label>
                     <p class="mt-1 text-xs text-slate-500">Bestimmt, in welchen Kategorien das Item später gefiltert werden kann.</p>
-                    <p id="itemTypeError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="item_type_id"></p>
+                    <p id="itemTypeError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="item_type_id" role="alert" aria-live="assertive"></p>
                   </div>
                   <div>
                     <label class="block" for="item-material-select">
@@ -347,7 +349,7 @@
                       ></select>
                     </label>
                     <p class="mt-1 text-xs text-slate-500">Wird u.&nbsp;a. für die Textur und im Tooltip angezeigt.</p>
-                    <p id="itemMaterialError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="material_id"></p>
+                    <p id="itemMaterialError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="material_id" role="alert" aria-live="assertive"></p>
                   </div>
                   <div>
                     <label class="block" for="item-rarity-select">
@@ -361,7 +363,7 @@
                       ></select>
                     </label>
                     <p class="mt-1 text-xs text-slate-500">Legt die Farbgebung und Drop-Chance des Items fest.</p>
-                    <p id="itemRarityError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="rarity_id"></p>
+                    <p id="itemRarityError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="rarity_id" role="alert" aria-live="assertive"></p>
                   </div>
                 </div>
                 <div>
@@ -425,7 +427,7 @@
                       <span aria-hidden="true" data-star-icon>☆</span>
                     </button>
                   </div>
-                  <p id="itemStarsError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="stars"></p>
+                  <p id="itemStarsError" class="mt-1 text-xs text-rose-400 hidden" data-error-for="stars" role="alert" aria-live="assertive"></p>
                 </div>
               </div>
             </section>
@@ -476,7 +478,7 @@
                   </div>
                 </div>
               </div>
-              <p class="text-xs text-rose-400 hidden" data-error-for="enchantments"></p>n
+              <p class="text-xs text-rose-400 hidden" data-error-for="enchantments" role="alert" aria-live="assertive"></p>n
             </section>
             <section aria-labelledby="addItemFormMedia" class="space-y-4">
               <div class="space-y-1">
@@ -586,7 +588,7 @@
                   <p id="itemImageHelp" class="text-xs text-slate-500">
                     Unterstützte Formate: PNG, JPG, WebP · Maximal 5&nbsp;MB. Sie können auch ein Bild aus der Zwischenablage einfügen (Strg+V).
                   </p>
-                  <p id="itemImageError" class="text-xs text-rose-400 hidden" data-error-for="itemImage"></p>
+                  <p id="itemImageError" class="text-xs text-rose-400 hidden" data-error-for="itemImage" role="alert" aria-live="assertive"></p>
                 </div>
                 <div class="space-y-2">
                   <label class="text-sm font-medium text-slate-300" for="itemLoreImage">Lore-Bild (optional)</label>
@@ -690,7 +692,7 @@
                   <p id="itemLoreImageHelp" class="text-xs text-slate-500">
                     Optionales Zusatzbild für Lore-Ansichten. Unterstützte Formate wie oben. Sie können auch ein Bild aus der Zwischenablage einfügen (Strg+V).
                   </p>
-                  <p id="itemLoreImageError" class="text-xs text-rose-400 hidden" data-error-for="itemLoreImage"></p>
+                  <p id="itemLoreImageError" class="text-xs text-rose-400 hidden" data-error-for="itemLoreImage" role="alert" aria-live="assertive"></p>
                 </div>
               </div>
             </section>
@@ -706,6 +708,7 @@
                 type="submit"
                 class="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-emerald-950 shadow-emerald-500/0 transition hover:bg-emerald-400 focus:outline-none focus-visible:ring focus-visible:ring-emerald-500/60"
                 id="addItemSubmit"
+                aria-busy="false"
               >
                 <span>Speichern</span>
                 <svg

--- a/app/public/public/js/app.js
+++ b/app/public/public/js/app.js
@@ -997,6 +997,7 @@ function openAddItemModal() {
   if (!elements.addItemModal) return
   elements.addItemModal.classList.remove('hidden')
   elements.addItemModal.setAttribute('aria-hidden', 'false')
+  document.documentElement.style.overflow = 'hidden'
   window.setTimeout(() => {
     const firstField = elements.addItemForm?.querySelector('input, select, textarea')
     if (firstField instanceof HTMLElement) {
@@ -1009,6 +1010,7 @@ function closeAddItemModal() {
   if (!elements.addItemModal) return
   elements.addItemModal.classList.add('hidden')
   elements.addItemModal.setAttribute('aria-hidden', 'true')
+  document.documentElement.style.removeProperty('overflow')
   resetAddItemForm()
 }
 
@@ -1033,9 +1035,15 @@ function resetAddItemForm() {
 }
 
 function toggleSubmitLoading(isLoading) {
-  if (elements.submitButton) {
-    elements.submitButton.disabled = Boolean(isLoading)
-    elements.submitButton.classList.toggle('opacity-75', Boolean(isLoading))
+  const form = elements.addItemForm
+  if (form instanceof HTMLFormElement) {
+    form.setAttribute('aria-busy', isLoading ? 'true' : 'false')
+  }
+  const submitButton = elements.submitButton
+  if (submitButton instanceof HTMLButtonElement) {
+    submitButton.disabled = Boolean(isLoading)
+    submitButton.classList.toggle('opacity-75', Boolean(isLoading))
+    submitButton.setAttribute('aria-busy', isLoading ? 'true' : 'false')
   }
   elements.submitSpinner?.classList.toggle('hidden', !isLoading)
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -15,3 +15,9 @@ body,
 body {
   background-color: #020617;
 }
+
+@supports (height: 100svh) {
+  .modal-viewport {
+    max-height: min(66svh, calc(100svh - 3rem));
+  }
+}


### PR DESCRIPTION
## Summary
- enhance the add-item modal header and copy with sticky styling and a required-field hint
- add live-region semantics, busy state handling, and scroll locking for the modal workflow
- introduce a modal viewport utility for small viewports via CSS support query

## Testing
- npm run build *(fails: vite binary not executable in repository checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68d5512c457c8324a94557f065f0237a