### PR TITLE
Normalize moderation is_published parameter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ cd worker
 npx wrangler deploy
 ```
 
+> Eine ausführlichere Schritt-für-Schritt-Anleitung findest du in [docs/worker-deployment.md](docs/worker-deployment.md).
+
 ### 5) Umgebungsvariablen setzen
 Im Cloudflare Dashboard oder via Wrangler (secrets):
 - `SUPABASE_URL`

--- a/docs/worker-deployment.md
+++ b/docs/worker-deployment.md
@@ -1,0 +1,39 @@
+# Cloudflare Worker Deployment Guide
+
+Dieser Leitfaden beschreibt, wie du den API-Worker nach einer Codeänderung neu deployen kannst.
+
+## Voraussetzungen
+
+- Du hast die [Wrangler-CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) installiert und bist über `wrangler login` bei Cloudflare authentifiziert.
+- Im Projektverzeichnis `worker/` liegt eine gültige `wrangler.toml`-Konfiguration mit dem Namen deines Workers.
+- Alle benötigten Secrets (z. B. `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`) sind in Cloudflare hinterlegt. Falls nicht, kannst du sie per `npx wrangler secret put <NAME>` setzen.
+
+## Deployment-Schritte
+
+1. **In das Worker-Verzeichnis wechseln**
+   ```bash
+   cd worker
+   ```
+2. **Abhängigkeiten installieren (falls noch nicht geschehen)**
+   ```bash
+   npm install
+   ```
+3. **Optional: Lokalen Testlauf starten**
+   ```bash
+   npx wrangler dev --remote
+   ```
+   So kannst du prüfen, ob der Worker fehlerfrei läuft, bevor du ihn veröffentlichst.
+4. **Deployment ausführen**
+   ```bash
+   npx wrangler deploy
+   ```
+   Wrangler baut den Worker, lädt ihn zu Cloudflare hoch und ersetzt die aktive Version.
+5. **Ergebnis überprüfen**
+   - Die URL des Workers findest du nach dem Deploy in der Wrangler-Ausgabe oder im Cloudflare-Dashboard.
+   - Kontrolliere die Logs mit `npx wrangler tail`, um sicherzustellen, dass keine Fehler auftreten.
+
+## Rollback
+
+Falls du zur vorherigen Version zurückkehren möchtest, kannst du im Cloudflare-Dashboard unter **Workers & Pages → Workers → Deployments** eine ältere Veröffentlichung aktivieren oder den letzten funktionierenden Commit erneut deployen.
+
+Viel Erfolg beim Deploy! ✨

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -931,6 +931,7 @@ api.get('/items', async (c) => {
   }
 
   if (isPublishedFilter !== null) {
+    params.delete('is_published')
     params.append('is_published', `is.${isPublishedFilter}`)
   }
 


### PR DESCRIPTION
## Summary
- ensure the moderation items endpoint always forwards a single `is_published=is.<value>` filter to Supabase

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2bc13d7483248c64e665d4cee4a1