### PR TITLE
Fix unpublished moderation query

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1451,7 +1451,7 @@ api.get('/items', async (c) => {
 
   if (isPublishedFilter !== null) {
     params.delete('is_published')
-    params.append('is_published', `is.${isPublishedFilter}`)
+    params.append('is_published', `eq.${isPublishedFilter}`)
   }
 
   params.append('order', 'title.asc')


### PR DESCRIPTION
## Summary
- ensure the moderation items endpoint uses an equality filter for the is_published flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5a4bb01c8324869238f70e36a539