### PR TITLE
Improve moderation filter normalization

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1093,6 +1093,14 @@ const extractBooleanFilter = (
 
     const lowered = normalized.toLowerCase()
 
+    if (lowered === 'is.true') {
+      return 'true'
+    }
+
+    if (lowered === 'is.false') {
+      return 'false'
+    }
+
     if (['true', '1', 'yes', 'y', 'on'].includes(lowered)) {
       return 'true'
     }
@@ -1450,8 +1458,7 @@ api.get('/items', async (c) => {
   }
 
   if (isPublishedFilter !== null) {
-    params.delete('is_published')
-    params.append('is_published', `is.${isPublishedFilter}`)
+    params.set('is_published', `eq.${isPublishedFilter}`)
   }
 
   params.append('order', 'title.asc')


### PR DESCRIPTION
## Summary
- normalize boolean filter parsing so legacy `is.true`/`is.false` values are converted to standard booleans before proxying to Supabase
- ensure the Supabase request always emits a single `eq.*` filter for `is_published`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd5a4bb01c8324869238f70e36a539