### PR TITLE
Normalize moderation boolean filters for Supabase

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1084,7 +1084,7 @@ const extractPositiveIntegerFilter = (
 
 const extractBooleanFilter = (
   ...candidates: Array<string | undefined>
-): 'true' | 'false' | null => {
+): 'TRUE' | 'FALSE' | null => {
   for (const candidate of candidates) {
     const normalized = normalizeFilterValue(candidate)
     if (!normalized) {
@@ -1093,12 +1093,20 @@ const extractBooleanFilter = (
 
     const lowered = normalized.toLowerCase()
 
+    if (lowered === 'is.true') {
+      return 'TRUE'
+    }
+
+    if (lowered === 'is.false') {
+      return 'FALSE'
+    }
+
     if (['true', '1', 'yes', 'y', 'on'].includes(lowered)) {
-      return 'true'
+      return 'TRUE'
     }
 
     if (['false', '0', 'no', 'n', 'off'].includes(lowered)) {
-      return 'false'
+      return 'FALSE'
     }
   }
 
@@ -1450,8 +1458,7 @@ api.get('/items', async (c) => {
   }
 
   if (isPublishedFilter !== null) {
-    params.delete('is_published')
-    params.append('is_published', `is.${isPublishedFilter}`)
+    params.set('is_published', `eq.${isPublishedFilter}`)
   }
 
   params.append('order', 'title.asc')


### PR DESCRIPTION
## Summary
- ensure moderation boolean filters normalize to uppercase TRUE/FALSE values expected by Supabase

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd5a4bb01c8324869238f70e36a539