### PR TITLE
Fix boolean filter mapping for item list endpoint

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1084,7 +1084,7 @@ const extractPositiveIntegerFilter = (
 
 const extractBooleanFilter = (
   ...candidates: Array<string | undefined>
-): 'TRUE' | 'FALSE' | null => {
+): 'true' | 'false' | null => {
   for (const candidate of candidates) {
     const normalized = normalizeFilterValue(candidate)
     if (!normalized) {
@@ -1094,19 +1094,19 @@ const extractBooleanFilter = (
     const lowered = normalized.toLowerCase()
 
     if (lowered === 'is.true') {
-      return 'TRUE'
+      return 'true'
     }
 
     if (lowered === 'is.false') {
-      return 'FALSE'
+      return 'false'
     }
 
     if (['true', '1', 'yes', 'y', 'on'].includes(lowered)) {
-      return 'TRUE'
+      return 'true'
     }
 
     if (['false', '0', 'no', 'n', 'off'].includes(lowered)) {
-      return 'FALSE'
+      return 'false'
     }
   }
 


### PR DESCRIPTION
## Summary
- normalize the boolean filter helper to return lowercase values so the Supabase `eq` filter stays valid

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd982a64648324909a7c3576f3c6e8