### PR TITLE
Restrict item insert policy to creators

### DIFF
--- a/supabase/migrations/20251002062000_remote_schema.sql
+++ b/supabase/migrations/20251002062000_remote_schema.sql
@@ -546,11 +546,7 @@ CREATE POLICY "items_delete_mod_or_admin" ON "public"."items" FOR DELETE TO "aut
 
 
 
-CREATE POLICY "items_insert_all_auth" ON "public"."items" FOR INSERT TO "authenticated" WITH CHECK (true);
-
-
-
-CREATE POLICY "items_insert_own" ON "public"."items" FOR INSERT TO "authenticated" WITH CHECK (("created_by" = "auth"."uid"()));
+CREATE POLICY "items_insert_own" ON "public"."items" FOR INSERT TO "authenticated" WITH CHECK ((("created_by" = "auth"."uid"()) AND ((NOT "is_published") OR "public"."is_moderator_or_admin"())));
 
 
 


### PR DESCRIPTION
## Summary
- remove the broad `items_insert_all_auth` rule on `public.items`
- tighten the remaining insert policy so only the creator can insert
- require moderator or admin privileges to set `is_published` during insert

## Testing
- not run (Supabase CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68de1d74705c832483452d2270d04b59