### PR TITLE
Ensure Supabase types file uses text diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/types/supabase.ts text diff


### PR DESCRIPTION
## Summary
- configure Git attributes so src/types/supabase.ts always uses the default text diff driver

## Testing
- git diff HEAD^ HEAD -- src/types/supabase.ts


------
https://chatgpt.com/codex/tasks/task_e_68de272411808324ab13deb34e321d9c