### PR TITLE
Fetch search filters from Supabase REST API

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1168,46 +1168,70 @@ export default function App() {
   const metadataAbortControllerRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
-    const supabase = getSupabaseClient()
-    if (!supabase) {
+    const { url, anonKey } = getSupabaseConfig()
+    if (!url || !anonKey) {
       return
     }
 
+    const controller = new AbortController()
     let isCancelled = false
 
     const loadReferenceData = async () => {
       try {
-        const [itemTypesResult, materialsResult, raritiesResult] = await Promise.all([
-          supabase.from('item_types').select('*').order('label', { ascending: true }),
-          supabase.from('materials').select('*').order('label', { ascending: true }),
-          supabase.from('rarities').select('*').order('label', { ascending: true })
+        const sessionToken = getSupabaseAccessToken()
+        const headers: HeadersInit = {
+          apikey: anonKey,
+          accept: 'application/json',
+        }
+
+        if (sessionToken) {
+          headers.Authorization = `Bearer ${sessionToken}`
+        }
+
+        const requestInit: RequestInit = {
+          headers,
+          signal: controller.signal,
+        }
+
+        const [itemTypesResponse, materialsResponse, raritiesResponse] = await Promise.all([
+          fetch(`${url}/rest/v1/item_types?select=*`, requestInit),
+          fetch(`${url}/rest/v1/materials?select=*`, requestInit),
+          fetch(`${url}/rest/v1/rarities?select=*`, requestInit),
         ])
 
-        if (isCancelled) {
+        if (!itemTypesResponse.ok || !materialsResponse.ok || !raritiesResponse.ok) {
+          throw new Error('Stammdaten konnten nicht geladen werden.')
+        }
+
+        const [itemTypesJson, materialsJson, raritiesJson] = await Promise.all([
+          itemTypesResponse.json(),
+          materialsResponse.json(),
+          raritiesResponse.json(),
+        ])
+
+        if (controller.signal.aborted || isCancelled) {
           return
         }
 
-        if (!itemTypesResult.error && Array.isArray(itemTypesResult.data)) {
-          const options = createReferenceOptionsFromRecords(itemTypesResult.data, 'Typ')
-          if (options.length > 0) {
-            setTypeOptions([{ value: '', label: 'Alle Typen' }, ...options])
-          }
+        const nextTypeOptions = createReferenceOptionsFromRecords(itemTypesJson, 'Typ')
+        if (nextTypeOptions.length > 0) {
+          setTypeOptions([{ value: '', label: 'Alle Item-Typen' }, ...nextTypeOptions])
         }
 
-        if (!materialsResult.error && Array.isArray(materialsResult.data)) {
-          const options = createReferenceOptionsFromRecords(materialsResult.data, 'Material')
-          if (options.length > 0) {
-            setMaterialOptions([{ value: '', label: 'Alle Materialien' }, ...options])
-          }
+        const nextMaterialOptions = createReferenceOptionsFromRecords(materialsJson, 'Material')
+        if (nextMaterialOptions.length > 0) {
+          setMaterialOptions([{ value: '', label: 'Alle Materialien' }, ...nextMaterialOptions])
         }
 
-        if (!raritiesResult.error && Array.isArray(raritiesResult.data)) {
-          const options = createRarityOptionsFromRecords(raritiesResult.data)
-          if (options.length > 0) {
-            setRarityOptions([{ value: '', label: 'Alle Seltenheiten' }, ...options])
-          }
+        const nextRarityOptions = createRarityOptionsFromRecords(raritiesJson)
+        if (nextRarityOptions.length > 0) {
+          setRarityOptions([{ value: '', label: 'Alle Seltenheiten' }, ...nextRarityOptions])
         }
       } catch (error) {
+        if (controller.signal.aborted || isCancelled) {
+          return
+        }
+
         console.warn('Referenzdaten konnten nicht geladen werden.', error)
       }
     }
@@ -1216,6 +1240,7 @@ export default function App() {
 
     return () => {
       isCancelled = true
+      controller.abort()
     }
   }, [])
 
@@ -1518,38 +1543,19 @@ export default function App() {
     [rarityLookupMap, rarityOptionById, rarityOptionByCode, rarityLabelMap]
   )
 
-  const filterTypeOptions = useMemo(() => {
-    return [
-      { value: '', label: 'Alle Item-Typen' },
-      ...itemTypeOptionsState.map((option) => ({
-        value: option.value,
-        label: option.label,
-        supabaseValue: option.supabaseValue,
-      })),
-    ] satisfies FilterOption[]
-  }, [itemTypeOptionsState])
+  const filterTypeOptions = useMemo<FilterOption[]>(() => {
+    return typeOptions.map((option) =>
+      option.value === '' ? { ...option, label: 'Alle Item-Typen' } : option
+    )
+  }, [typeOptions])
 
-  const filterMaterialOptions = useMemo(() => {
-    return [
-      { value: '', label: 'Alle Materialien' },
-      ...materialOptionsState.map((option) => ({
-        value: option.value,
-        label: option.label,
-        supabaseValue: option.supabaseValue,
-      })),
-    ] satisfies FilterOption[]
-  }, [materialOptionsState])
+  const filterMaterialOptions = useMemo<FilterOption[]>(() => {
+    return materialOptions
+  }, [materialOptions])
 
-  const filterRarityOptions = useMemo(() => {
-    return [
-      { value: '', label: 'Alle Seltenheiten' },
-      ...rarityOptionsState.map((option) => ({
-        value: option.value,
-        label: option.label,
-        supabaseValue: option.supabaseValue,
-      })),
-    ] satisfies FilterOption[]
-  }, [rarityOptionsState])
+  const filterRarityOptions = useMemo<FilterOption[]>(() => {
+    return rarityOptions
+  }, [rarityOptions])
 
   const fetchItems = useCallback(
     async ({ search, type, material, rarity }: FetchItemsParams) => {
@@ -1642,7 +1648,7 @@ export default function App() {
         }
       }
     },
-    [itemTypeOptionsState, materialOptionsState, rarityOptionsState]
+    [typeOptions, materialOptions, rarityOptions]
   )
 
   const dismissToast = useCallback((id: number) => {


### PR DESCRIPTION
## Summary
- replace the initial reference-data effect to call the Supabase REST endpoints directly when populating the search filter options
- hydrate the type, material, and rarity select lists from the REST responses so they are immediately filled on page load
- reuse the existing fallback label for the blank item-type entry while keeping the rest of the filter options unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2e63f25c8324bfc7f33a5af3d60a